### PR TITLE
Feat/add gemini insight option

### DIFF
--- a/pkg/client/fern_api_client.go
+++ b/pkg/client/fern_api_client.go
@@ -6,17 +6,19 @@ import (
 )
 
 type FernApiClient struct {
-	name       string
-	httpClient *http.Client
-	baseURL    string
+	name              string
+	httpClient        *http.Client
+	baseURL           string
+	enableGeminiInsights bool
 }
 
 type ClientOption func(*FernApiClient)
 
 func New(testName string, options ...ClientOption) *FernApiClient {
 	f := &FernApiClient{
-		name:       testName,
-		httpClient: http.DefaultClient,
+		name:                 testName,
+		httpClient:           http.DefaultClient,
+		enableGeminiInsights: false, // Default to false
 	}
 
 	for _, o := range options {
@@ -41,5 +43,11 @@ func WithBaseURL(baseURL string) ClientOption {
 func WithTimeout(timeout time.Duration) ClientOption {
 	return func(ac *FernApiClient) {
 		ac.httpClient.Timeout = timeout
+	}
+}
+
+func WithGeminiInsights(enable bool) ClientOption {
+	return func(ac *FernApiClient) {
+		ac.enableGeminiInsights = enable
 	}
 }

--- a/pkg/client/fern_api_client_test.go
+++ b/pkg/client/fern_api_client_test.go
@@ -3,9 +3,10 @@ package client_test
 import (
 	"time"
 
-	"github.com/guidewire/fern-ginkgo-client/pkg/client"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/guidewire/fern-ginkgo-client/pkg/client"
 )
 
 var _ = Describe("FernApiClient", func() {
@@ -41,4 +42,12 @@ var _ = Describe("FernApiClient", func() {
 
 	})
 
+	It("should get a new client with Gemini Insights enabled", func() {
+		
+		fernApiClient := client.New("test", client.WithGeminiInsights(true))
+
+		Expect(fernApiClient).ToNot(BeNil())
+		// We need to add a method to check if Gemini Insights is enabled
+		// For now, we'll just check that the client is created
+	})
 })

--- a/pkg/client/ginkgo_fern_reporter.go
+++ b/pkg/client/ginkgo_fern_reporter.go
@@ -8,9 +8,9 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/guidewire/fern-ginkgo-client/pkg/models"
-
 	gt "github.com/onsi/ginkgo/v2/types"
+
+	"github.com/guidewire/fern-ginkgo-client/pkg/models"
 )
 
 func (f *FernApiClient) Report(testName string, report gt.Report) error {
@@ -43,11 +43,12 @@ func (f *FernApiClient) Report(testName string, report gt.Report) error {
 	suiteRuns = append(suiteRuns, suiteRun)
 
 	testRun := models.TestRun{
-		TestProjectName: f.name, // Set this to your project name
-		TestSeed:        uint64(report.SuiteConfig.RandomSeed),
-		StartTime:       report.StartTime,
-		EndTime:         time.Now(), // or report.EndTime if available
-		SuiteRuns:       suiteRuns,
+		TestProjectName:      f.name, // Set this to your project name
+		TestSeed:             uint64(report.SuiteConfig.RandomSeed),
+		StartTime:            report.StartTime,
+		EndTime:              time.Now(), // or report.EndTime if available
+		SuiteRuns:            suiteRuns,
+		EnableGeminiInsights: f.enableGeminiInsights,
 	}
 
 	testJson, err := json.Marshal(testRun)

--- a/pkg/models/types.go
+++ b/pkg/models/types.go
@@ -16,6 +16,7 @@ type TestRun struct {
 	StartTime       time.Time  `json:"start_time"`
 	EndTime         time.Time  `json:"end_time"`
 	SuiteRuns       []SuiteRun `json:"suite_runs" gorm:"foreignKey:TestRunID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE"`
+	EnableGeminiInsights bool       `json:"enable_gemini_insights"`
 }
 
 type SuiteRun struct {

--- a/tests/adder_test.go
+++ b/tests/adder_test.go
@@ -3,8 +3,8 @@ package tests_test
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-  fern "github.com/guidewire/fern-ginkgo-client/pkg/client"
 
+  fern "github.com/guidewire/fern-ginkgo-client/pkg/client"
 	. "github.com/guidewire/fern-ginkgo-client/tests"
 )
 
@@ -22,6 +22,7 @@ var _ = Describe("Adder", func() {
 var _ = ReportAfterSuite("", func(report Report) {
     f := fern.New("Example Test",
         fern.WithBaseURL("http://localhost:8080/"),
+		fern.WithGeminiInsights(false),
     )
 
     err := f.Report("example test", report)


### PR DESCRIPTION
Fixes #9

Changes made:
* Adds `enableGeminiInsights` as an optional parameter in Fern client with default value to false
* Modifies the required struct and adds the corresponding test case

