### PR TITLE
feat: Collect meta information from the test and send to fern-reporter

### DIFF
--- a/pkg/client/fern_api_client.go
+++ b/pkg/client/fern_api_client.go
@@ -6,9 +6,14 @@ import (
 )
 
 type FernApiClient struct {
-	name       string
-	httpClient *http.Client
-	baseURL    string
+	name          string
+	httpClient    *http.Client
+	baseURL       string
+	username      string
+	branch        string
+	gitSHA        string
+	project       string
+	componentName string
 }
 
 type ClientOption func(*FernApiClient)
@@ -41,5 +46,35 @@ func WithBaseURL(baseURL string) ClientOption {
 func WithTimeout(timeout time.Duration) ClientOption {
 	return func(ac *FernApiClient) {
 		ac.httpClient.Timeout = timeout
+	}
+}
+
+func WithUsername(username string) ClientOption {
+	return func(ac *FernApiClient) {
+		ac.username = username
+	}
+}
+
+func WithBranch(branch string) ClientOption {
+	return func(ac *FernApiClient) {
+		ac.branch = branch
+	}
+}
+
+func WithGitSHA(sha string) ClientOption {
+	return func(ac *FernApiClient) {
+		ac.gitSHA = sha
+	}
+}
+
+func WithProject(project string) ClientOption {
+	return func(ac *FernApiClient) {
+		ac.project = project
+	}
+}
+
+func WithComponentName(component string) ClientOption {
+	return func(ac *FernApiClient) {
+		ac.componentName = component
 	}
 }

--- a/pkg/client/ginkgo_fern_reporter.go
+++ b/pkg/client/ginkgo_fern_reporter.go
@@ -48,6 +48,11 @@ func (f *FernApiClient) Report(testName string, report gt.Report) error {
 		StartTime:       report.StartTime,
 		EndTime:         time.Now(), // or report.EndTime if available
 		SuiteRuns:       suiteRuns,
+		Username:        f.username,
+		Branch:          f.branch,
+		GitSHA:          f.gitSHA,
+		Project:         f.project,
+		ComponentName:   f.componentName,
 	}
 
 	testJson, err := json.Marshal(testRun)

--- a/pkg/models/types.go
+++ b/pkg/models/types.go
@@ -16,6 +16,11 @@ type TestRun struct {
 	StartTime       time.Time  `json:"start_time"`
 	EndTime         time.Time  `json:"end_time"`
 	SuiteRuns       []SuiteRun `json:"suite_runs" gorm:"foreignKey:TestRunID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE"`
+	Username        string     `json:"username"`
+	Branch          string     `json:"branch"`
+	GitSHA          string     `json:"git_sha"`
+	Project         string     `json:"project"`
+	ComponentName   string     `json:"component_name"`
 }
 
 type SuiteRun struct {

--- a/tests/adder_test.go
+++ b/tests/adder_test.go
@@ -1,6 +1,10 @@
 package tests_test
 
 import (
+	"os"
+	"os/exec"
+	"strings"
+
 	fern "github.com/guidewire-oss/fern-ginkgo-client/pkg/client"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -22,9 +26,32 @@ var _ = Describe("Adder", func() {
 var _ = ReportAfterSuite("", func(report Report) {
 	f := fern.New("Example Test",
 		fern.WithBaseURL("http://localhost:8080/"),
+		fern.WithUsername(os.Getenv("USER")),
+		fern.WithBranch(getGitBranch()),
+		fern.WithGitSHA(getGitSHA()),
+		fern.WithProject("fern-ginkgo-client"),
+		fern.WithComponentName("adder"),
 	)
 
 	err := f.Report("example test", report)
 
 	Expect(err).To(BeNil(), "Unable to create reporter file")
 })
+
+func getGitBranch() string {
+	cmd := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD")
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func getGitSHA() string {
+	cmd := exec.Command("git", "rev-parse", "HEAD")
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}


### PR DESCRIPTION
- Added functionality to gather username, branch, Git SHA, project, and component name.
- Integrated meta information into the report payload sent to fern-reporter.