### PR TITLE
Fix: send spec tags at spec level and suite at suite level #10

### DIFF
--- a/pkg/client/ginkgo_fern_reporter.go
+++ b/pkg/client/ginkgo_fern_reporter.go
@@ -24,6 +24,7 @@ func (f *FernApiClient) Report(report gt.Report) error {
 		SuiteName: report.SuiteDescription,
 		StartTime: report.StartTime,
 		EndTime:   report.EndTime,
+		Tags:      convertTags(report.SuiteLabels),
 	}
 
 	var specRuns []models.SpecRun
@@ -34,12 +35,8 @@ func (f *FernApiClient) Report(report gt.Report) error {
 			Message:         spec.Failure.Message,
 			StartTime:       spec.StartTime,
 			EndTime:         spec.EndTime,
+			Tags:            convertTags(spec.Labels()),
 		}
-
-		// Accessing the suite labels
-		labels := report.SuiteLabels
-		// logic to convert suite labels string to []Tag
-		specRun.Tags = convertTags(labels)
 		specRuns = append(specRuns, specRun)
 	}
 

--- a/pkg/models/types.go
+++ b/pkg/models/types.go
@@ -10,7 +10,7 @@ type TimeLog struct {
 }
 
 type TestRun struct {
-	ID                uint64     `json:"id" gorm:"primaryKey"`
+	ID                uint64     `json:"id"`
 	TestProjectName   string     `json:"test_project_name"`
 	TestProjectID     string     `json:"test_project_id"`
 	TestSeed          uint64     `json:"test_seed"`
@@ -20,30 +20,31 @@ type TestRun struct {
 	GitSha            string     `json:"git_sha"`
 	BuildTriggerActor string     `json:"build_trigger_actor"`
 	BuildUrl          string     `json:"build_url"`
-	SuiteRuns         []SuiteRun `json:"suite_runs" gorm:"foreignKey:TestRunID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE"`
+	SuiteRuns         []SuiteRun `json:"suite_runs"`
 }
 
 type SuiteRun struct {
-	ID        uint64    `json:"id" gorm:"primaryKey"`
+	ID        uint64    `json:"id"`
 	TestRunID uint64    `json:"test_run_id"`
 	SuiteName string    `json:"suite_name"`
 	StartTime time.Time `json:"start_time"`
 	EndTime   time.Time `json:"end_time"`
-	SpecRuns  []SpecRun `json:"spec_runs" gorm:"foreignKey:SuiteID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE"`
+	Tags      []Tag     `json:"tags"`
+	SpecRuns  []SpecRun `json:"spec_runs"`
 }
 
 type SpecRun struct {
-	ID              uint64    `json:"id" gorm:"primaryKey"`
+	ID              uint64    `json:"id"`
 	SuiteID         uint64    `json:"suite_id"`
 	SpecDescription string    `json:"spec_description"`
 	Status          string    `json:"status"`
 	Message         string    `json:"message"`
-	Tags            []Tag     `json:"tags" gorm:"many2many:spec_run_tags;"`
 	StartTime       time.Time `json:"start_time"`
 	EndTime         time.Time `json:"end_time"`
+	Tags            []Tag     `json:"tags"`
 }
 
 type Tag struct {
-	ID   uint64 `json:"id" gorm:"primaryKey"`
+	ID   uint64 `json:"id"`
 	Name string `json:"name"`
 }

--- a/tests/adder_test.go
+++ b/tests/adder_test.go
@@ -9,12 +9,12 @@ import (
 var _ = Describe("Adder", Ordered, Label("unit"), func() {
 	Describe("Add", func() {
 
-		It("adds two numbers", func() {
+		It("adds two numbers", Label("add 1"), func() {
 			sum := Add(2, 3)
 			Expect(sum).To(Equal(5))
 		})
 
-		It("adds two numbers, where one is negative", func() {
+		It("adds two numbers, where one is negative", Label("add 2"), func() {
 			sum := Add(2, -3)
 			Expect(sum).To(Equal(-1))
 		})


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Spec tags are now sent at the spec level and suite tags at the suite level, matching the correct scope for each.

- **Bug Fixes**
  - Fixed tag assignment so spec tags are only attached to specs, and suite tags are only attached to suites.

<!-- End of auto-generated description by cubic. -->

