### PR TITLE
Feat: Support sending test data to auth enabled Fern Platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,13 @@ Sample Response:
    ```bash
    ginkgo -r -p --label-filter=unit --randomize-all
    ```
-
+4. **Authentication**: when using the Fern Platform (which has authentication enabled), set the following environment variables:
+   ```shell
+    export CLIENT_ID=<Your Service Application Client ID>
+    export CLIENT_SECRET=<Your Service Application Client Secret>
+    export AUTH_URL=<Base URL of your authentication server>
+    export FERN_GINKGO_CLIENT_SCOPE=<Fern Platform scope for Testrun write>
+   ```
 ### See Also
 1. [Fern UI](https://github.com/Guidewire/fern-ui)
 2. [Fern Ginkgo Reporter](https://github.com/Guidewire/fern-reporter)

--- a/pkg/client/client_suite_test.go
+++ b/pkg/client/client_suite_test.go
@@ -1,8 +1,9 @@
 package client_test
 
 import (
-	"github.com/guidewire-oss/fern-ginkgo-client/tests"
 	"testing"
+
+	"github.com/guidewire-oss/fern-ginkgo-client/tests"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/pkg/client/fern_api_client.go
+++ b/pkg/client/fern_api_client.go
@@ -1,29 +1,107 @@
 package client
 
 import (
+	"bytes"
+	"encoding/json"
+	"fmt"
 	"net/http"
+	"net/url"
+	"os"
+	"strings"
 	"time"
 )
 
 type FernApiClient struct {
-	id         string
-	httpClient *http.Client
-	baseURL    string
+	id           string
+	httpClient   *http.Client
+	baseURL      string
+	token        string
+	clientID     string
+	clientSecret string
+	authURL      string
+	scope        string
 }
 
 type ClientOption func(*FernApiClient)
 
-func New(projectId string, options ...ClientOption) *FernApiClient {
+type TokenResponse struct {
+	AccessToken string `json:"access_token"`
+	TokenType   string `json:"token_type"`
+	ExpiresIn   int    `json:"expires_in"`
+}
+
+func New(projectId string, options ...ClientOption) (*FernApiClient, error) {
 	f := &FernApiClient{
-		id:         projectId,
-		httpClient: http.DefaultClient,
+		id:           projectId,
+		httpClient:   http.DefaultClient,
+		clientID:     os.Getenv("FERN_AUTH_CLIENT_ID"),
+		clientSecret: os.Getenv("FERN_AUTH_CLIENT_SECRET"),
+		authURL:      os.Getenv("AUTH_URL"),
+		scope:        getEnvOrDefault("FERN_GINKGO_CLIENT_SCOPE", "fern.testrun.write"),
 	}
 
 	for _, o := range options {
 		o(f)
 	}
 
-	return f
+	// Generate token if credentials are available
+	if f.clientID != "" && f.clientSecret != "" && f.authURL != "" {
+		if err := f.generateToken(); err != nil {
+			return f, fmt.Errorf("failed to generate token: %w", err)
+		}
+	}
+
+	return f, nil
+}
+
+func (f *FernApiClient) generateToken() error {
+	tokenURL := strings.TrimRight(f.authURL, "/") + "/token"
+
+	// Prepare the request body for client credentials flow
+	data := url.Values{}
+	data.Set("grant_type", "client_credentials")
+	data.Set("client_id", f.clientID)
+	data.Set("client_secret", f.clientSecret)
+	data.Set("scope", f.scope)
+
+	req, err := http.NewRequest("POST", tokenURL, bytes.NewBufferString(data.Encode()))
+	if err != nil {
+		return fmt.Errorf("failed to create token request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := f.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to make token request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("token request failed with status: %d", resp.StatusCode)
+	}
+
+	var tokenResp TokenResponse
+	if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
+		return fmt.Errorf("failed to decode token response: %w", err)
+	}
+
+	f.token = tokenResp.AccessToken
+	return nil
+}
+
+// GetToken returns the current access token
+func (f *FernApiClient) GetToken() string {
+	return f.token
+}
+
+// RefreshToken regenerates the access token
+func (f *FernApiClient) RefreshToken() error {
+	if f.clientID == "" || f.clientSecret == "" || f.authURL == "" {
+		return fmt.Errorf("missing credentials for token refresh")
+	}
+	return f.generateToken()
 }
 
 func WithHTTPClient(httpClient *http.Client) ClientOption {
@@ -42,4 +120,51 @@ func WithTimeout(timeout time.Duration) ClientOption {
 	return func(ac *FernApiClient) {
 		ac.httpClient.Timeout = timeout
 	}
+}
+
+func WithCredentials(clientID, clientSecret, authURL string) ClientOption {
+	return func(ac *FernApiClient) {
+		ac.clientID = clientID
+		ac.clientSecret = clientSecret
+		ac.authURL = authURL
+	}
+}
+
+func WithToken(token string) ClientOption {
+	return func(ac *FernApiClient) {
+		ac.token = token
+	}
+}
+
+// GetBaseURL returns the configured base URL
+func (f *FernApiClient) GetBaseURL() string {
+	return f.baseURL
+}
+
+// GetClientID returns the configured client ID
+func (f *FernApiClient) GetClientID() string {
+	return f.clientID
+}
+
+// GetClientSecret returns the configured client secret
+func (f *FernApiClient) getClientSecret() string {
+	return f.clientSecret
+}
+
+// GetAuthURL returns the configured auth URL
+func (f *FernApiClient) GetAuthURL() string {
+	return f.authURL
+}
+
+// GetHTTPClient returns the configured http.Client
+func (f *FernApiClient) GetHTTPClient() *http.Client {
+	return f.httpClient
+}
+
+func getEnvOrDefault(key, defaultVal string) string {
+	val := os.Getenv(key)
+	if val == "" {
+		return defaultVal
+	}
+	return val
 }

--- a/pkg/client/fern_api_client_test.go
+++ b/pkg/client/fern_api_client_test.go
@@ -1,44 +1,365 @@
-package client_test
+package client
 
 import (
+	_ "encoding/json"
+	"errors"
+	"io"
+	"io/ioutil"
+	"net/http"
+	_ "net/http/httptest"
+	"os"
+	_ "os"
+	"strings"
 	"time"
 
-	"github.com/guidewire-oss/fern-ginkgo-client/pkg/client"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("FernApiClient", Label("unit"), func() {
-	It("should get a new client", func() {
+// mockRoundTripper implements http.RoundTripper for mocking requests
+type mockRoundTripper struct {
+	roundTripFunc func(*http.Request) (*http.Response, error)
+}
 
-		fernApiClient := client.New("test")
+func (m *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return m.roundTripFunc(req)
+}
 
-		Expect(fernApiClient).ToNot(BeNil())
+var _ = Describe("FernApiClient", func() {
+	var mockHTTPClient *http.Client
 
+	var orig_client_id, orig_client_secret string
+
+	BeforeEach(func() {
+		mockHTTPClient = &http.Client{
+			Transport: &mockRoundTripper{},
+		}
+
+		orig_client_id = os.Getenv("FERN_AUTH_CLIENT_ID")
+		orig_client_secret = os.Getenv("FERN_AUTH_CLIENT_SECRET")
+		_ = os.Unsetenv("FERN_AUTH_CLIENT_ID")
+		_ = os.Unsetenv("FERN_AUTH_CLIENT_SECRET")
+		DeferCleanup(func() {
+			_ = os.Setenv("FERN_AUTH_CLIENT_ID", orig_client_id)
+			_ = os.Setenv("FERN_AUTH_CLIENT_SECRET", orig_client_secret)
+		})
 	})
 
-	It("should get a new client with BaseURL", func() {
+	Describe("New", func() {
+		It("creates client without credentials", func() {
+			c, err := New("proj1", WithHTTPClient(mockHTTPClient))
+			Expect(err).To(BeNil())
+			Expect(c).NotTo(BeNil())
+			Expect(c.GetToken()).To(Equal(""))
+		})
 
-		fernApiClient := client.New("test", client.WithBaseURL("test URL"))
-
-		Expect(fernApiClient).ToNot(BeNil())
-
+		It("returns error when token generation fails", func() {
+			rt := &mockRoundTripper{
+				roundTripFunc: func(req *http.Request) (*http.Response, error) {
+					return nil, errors.New("network error")
+				},
+			}
+			c, err := New("proj2",
+				WithHTTPClient(&http.Client{Transport: rt}),
+				WithCredentials("id", "secret", "http://auth"),
+			)
+			Expect(err).To(HaveOccurred())
+			Expect(c).NotTo(BeNil())
+		})
 	})
 
-	It("should get a new client with HTTP Client", func() {
+	Describe("generateToken", func() {
+		It("successfully sets token on valid response", func() {
+			tokenJSON := `{"access_token":"abc123","token_type":"bearer","expires_in":3600}`
+			rt := &mockRoundTripper{
+				roundTripFunc: func(req *http.Request) (*http.Response, error) {
+					Expect(req.Method).To(Equal("POST"))
+					Expect(req.URL.String()).To(Equal("http://auth/token"))
+					return &http.Response{
+						StatusCode: 200,
+						Body:       ioutil.NopCloser(strings.NewReader(tokenJSON)),
+					}, nil
+				},
+			}
+			c, err := New("proj3",
+				WithHTTPClient(&http.Client{Transport: rt}),
+				WithCredentials("id", "secret", "http://auth"),
+			)
+			Expect(err).To(BeNil())
+			Expect(c.GetToken()).To(Equal("abc123"))
+		})
 
-		fernApiClient := client.New("test", client.WithHTTPClient(nil))
+		It("returns error on http failure", func() {
+			rt := &mockRoundTripper{
+				roundTripFunc: func(req *http.Request) (*http.Response, error) {
+					return nil, errors.New("boom")
+				},
+			}
+			c, _ := New("projX",
+				WithHTTPClient(&http.Client{Transport: rt}),
+				WithCredentials("id", "secret", "http://auth"),
+			)
+			err := c.RefreshToken()
+			Expect(err).To(HaveOccurred())
+		})
 
-		Expect(fernApiClient).ToNot(BeNil())
+		It("returns error on non-200 response", func() {
+			rt := &mockRoundTripper{
+				roundTripFunc: func(req *http.Request) (*http.Response, error) {
+					return &http.Response{
+						StatusCode: 400,
+						Body:       io.NopCloser(strings.NewReader("bad")),
+					}, nil
+				},
+			}
+			_, err := New("projY",
+				WithHTTPClient(&http.Client{Transport: rt}),
+				WithCredentials("id", "secret", "http://auth"),
+			)
+			Expect(err).To(HaveOccurred())
+		})
 
+		It("returns error on invalid JSON", func() {
+			rt := &mockRoundTripper{
+				roundTripFunc: func(req *http.Request) (*http.Response, error) {
+					return &http.Response{
+						StatusCode: 200,
+						Body:       ioutil.NopCloser(strings.NewReader("not-json")),
+					}, nil
+				},
+			}
+			c, _ := New("projZ",
+				WithHTTPClient(&http.Client{Transport: rt}),
+				WithCredentials("id", "secret", "http://auth"),
+			)
+			err := c.RefreshToken()
+			Expect(err).To(HaveOccurred())
+		})
 	})
 
-	It("should get a new client with timeout", func() {
-
-		fernApiClient := client.New("test", client.WithTimeout(5*time.Second))
-
-		Expect(fernApiClient).ToNot(BeNil())
-
+	Describe("RefreshToken", func() {
+		It("returns error when missing credentials", func() {
+			c := FernApiClient{}
+			err := c.RefreshToken()
+			Expect(err).To(HaveOccurred())
+		})
 	})
 
+	Describe("Options", func() {
+		It("sets baseURL", func() {
+			c, _ := New("proj", WithBaseURL("http://api"))
+			Expect(c.GetBaseURL()).To(Equal("http://api"))
+		})
+
+		It("sets timeout", func() {
+			c, _ := New("proj", WithTimeout(2*time.Second))
+			Expect(c.GetHTTPClient().Timeout).To(Equal(2 * time.Second))
+		})
+
+		It("sets token", func() {
+			c, _ := New("proj", WithToken("tok123"))
+			Expect(c.GetToken()).To(Equal("tok123"))
+		})
+
+		It("sets credentials", func() {
+			c, _ := New("proj", WithCredentials("id", "secret", "http://auth"))
+			Expect(c.GetClientID()).To(Equal("id"))
+			Expect(c.getClientSecret()).To(Equal("secret"))
+			Expect(c.GetAuthURL()).To(Equal("http://auth"))
+		})
+	})
+})
+
+var _ = Describe("getEnvOrDefault", func() {
+	const (
+		testEnvKey     = "TEST_ENV_VAR"
+		testEnvValue   = "test_value"
+		defaultValue   = "default_value"
+		emptyValue     = ""
+		anotherKey     = "ANOTHER_TEST_KEY"
+		anotherValue   = "another_value"
+		anotherDefault = "another_default"
+	)
+
+	// Store original environment state for cleanup
+	var originalEnvValue string
+	var originalEnvExists bool
+
+	BeforeEach(func() {
+		// Store the original state of our test environment variable
+		originalEnvValue, originalEnvExists = os.LookupEnv(testEnvKey)
+
+		// Clean up any existing test environment variables
+		os.Unsetenv(testEnvKey)
+		os.Unsetenv(anotherKey)
+	})
+
+	AfterEach(func() {
+		// Restore original environment state
+		if originalEnvExists {
+			os.Setenv(testEnvKey, originalEnvValue)
+		} else {
+			os.Unsetenv(testEnvKey)
+		}
+
+		// Clean up test environment variables
+		os.Unsetenv(anotherKey)
+	})
+
+	Describe("when environment variable exists and has a value", func() {
+		BeforeEach(func() {
+			os.Setenv(testEnvKey, testEnvValue)
+		})
+
+		It("should return the environment variable value", func() {
+			result := getEnvOrDefault(testEnvKey, defaultValue)
+			Expect(result).To(Equal(testEnvValue))
+		})
+
+		It("should not return the default value", func() {
+			result := getEnvOrDefault(testEnvKey, defaultValue)
+			Expect(result).NotTo(Equal(defaultValue))
+		})
+	})
+
+	Describe("when environment variable does not exist", func() {
+		It("should return the default value", func() {
+			// Ensure the environment variable is not set
+			os.Unsetenv(testEnvKey)
+
+			result := getEnvOrDefault(testEnvKey, defaultValue)
+			Expect(result).To(Equal(defaultValue))
+		})
+	})
+
+	Describe("when environment variable exists but is empty", func() {
+		BeforeEach(func() {
+			os.Setenv(testEnvKey, emptyValue)
+		})
+
+		It("should return the default value", func() {
+			result := getEnvOrDefault(testEnvKey, defaultValue)
+			Expect(result).To(Equal(defaultValue))
+		})
+
+		It("should not return an empty string", func() {
+			result := getEnvOrDefault(testEnvKey, defaultValue)
+			Expect(result).NotTo(BeEmpty())
+		})
+	})
+
+	Describe("when default value is empty", func() {
+		Context("and environment variable exists with a value", func() {
+			BeforeEach(func() {
+				os.Setenv(testEnvKey, testEnvValue)
+			})
+
+			It("should return the environment variable value", func() {
+				result := getEnvOrDefault(testEnvKey, emptyValue)
+				Expect(result).To(Equal(testEnvValue))
+			})
+		})
+
+		Context("and environment variable does not exist", func() {
+			It("should return the empty default value", func() {
+				os.Unsetenv(testEnvKey)
+
+				result := getEnvOrDefault(testEnvKey, emptyValue)
+				Expect(result).To(Equal(emptyValue))
+				Expect(result).To(BeEmpty())
+			})
+		})
+
+		Context("and environment variable exists but is empty", func() {
+			BeforeEach(func() {
+				os.Setenv(testEnvKey, emptyValue)
+			})
+
+			It("should return the empty default value", func() {
+				result := getEnvOrDefault(testEnvKey, emptyValue)
+				Expect(result).To(Equal(emptyValue))
+				Expect(result).To(BeEmpty())
+			})
+		})
+	})
+
+	Describe("edge cases", func() {
+		Context("when environment variable contains only whitespace", func() {
+			BeforeEach(func() {
+				os.Setenv(testEnvKey, "   ")
+			})
+
+			It("should return the whitespace value, not the default", func() {
+				result := getEnvOrDefault(testEnvKey, defaultValue)
+				Expect(result).To(Equal("   "))
+				Expect(result).NotTo(Equal(defaultValue))
+			})
+		})
+
+		Context("when environment variable contains special characters", func() {
+			specialValue := "special!@#$%^&*()_+-={}[]|\\:;\"'<>?,./"
+
+			BeforeEach(func() {
+				os.Setenv(testEnvKey, specialValue)
+			})
+
+			It("should return the special characters value", func() {
+				result := getEnvOrDefault(testEnvKey, defaultValue)
+				Expect(result).To(Equal(specialValue))
+			})
+		})
+
+		Context("when environment variable contains newlines", func() {
+			multilineValue := "line1\nline2\nline3"
+
+			BeforeEach(func() {
+				os.Setenv(testEnvKey, multilineValue)
+			})
+
+			It("should return the multiline value", func() {
+				result := getEnvOrDefault(testEnvKey, defaultValue)
+				Expect(result).To(Equal(multilineValue))
+			})
+		})
+	})
+
+	Describe("multiple calls", func() {
+		It("should return consistent results for the same inputs", func() {
+			os.Setenv(testEnvKey, testEnvValue)
+
+			result1 := getEnvOrDefault(testEnvKey, defaultValue)
+			result2 := getEnvOrDefault(testEnvKey, defaultValue)
+
+			Expect(result1).To(Equal(result2))
+			Expect(result1).To(Equal(testEnvValue))
+		})
+
+		It("should handle different environment variables independently", func() {
+			os.Setenv(testEnvKey, testEnvValue)
+			os.Setenv(anotherKey, anotherValue)
+
+			result1 := getEnvOrDefault(testEnvKey, defaultValue)
+			result2 := getEnvOrDefault(anotherKey, anotherDefault)
+
+			Expect(result1).To(Equal(testEnvValue))
+			Expect(result2).To(Equal(anotherValue))
+		})
+	})
+
+	Describe("function signature and behavior", func() {
+		It("should accept string parameters and return string", func() {
+			result := getEnvOrDefault(testEnvKey, defaultValue)
+			Expect(result).To(BeAssignableToTypeOf(""))
+		})
+
+		It("should not modify environment variables", func() {
+			originalValue := "original"
+			os.Setenv(testEnvKey, originalValue)
+
+			getEnvOrDefault(testEnvKey, defaultValue)
+
+			currentValue := os.Getenv(testEnvKey)
+			Expect(currentValue).To(Equal(originalValue))
+		})
+	})
 })

--- a/pkg/client/ginkgo_fern_reporter.go
+++ b/pkg/client/ginkgo_fern_reporter.go
@@ -4,13 +4,14 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/go-git/go-git/v5"
-	"github.com/guidewire-oss/fern-ginkgo-client/pkg/utils"
 	"io"
 	"net/http"
 	"net/url"
 	"os"
 	"time"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/guidewire-oss/fern-ginkgo-client/pkg/utils"
 
 	"github.com/guidewire-oss/fern-ginkgo-client/pkg/models"
 
@@ -65,17 +66,27 @@ func (f *FernApiClient) Report(report gt.Report) error {
 
 	bodyReader := bytes.NewReader(testJson)
 
-	url, err := url.JoinPath(f.baseURL, "api/testrun")
+	var reportUrl string
+	if f.token != "" {
+		reportUrl, err = url.JoinPath(f.baseURL, "api/v1/test-runs")
+	} else {
+		reportUrl, err = url.JoinPath(f.baseURL, "api/testrun")
+	}
 	if err != nil {
 		return err
 	}
 
-	req, err := http.NewRequest(http.MethodPost, url, bodyReader)
+	req, err := http.NewRequest(http.MethodPost, reportUrl, bodyReader)
 	if err != nil {
 		return err
 	}
 
 	req.Header.Add("Content-Type", "application/json")
+
+	// Add authorization token if available
+	if f.token != "" {
+		req.Header.Set("Authorization", "Bearer "+f.token)
+	}
 	resp, err := f.httpClient.Do(req)
 	if err != nil {
 		fmt.Printf("client: error making http request: %s\n", err)

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -1,3 +1,3 @@
 package pkg
 
-const PROJECT_ID = "996ad860-2a9a-504f-8861-aeafd0b2ae29"
+const PROJECT_ID = "aaf6b6d4-d3a6-4e76-9aa6-a0bcaed53ebb"

--- a/pkg/utils/utils_suite_test.go
+++ b/pkg/utils/utils_suite_test.go
@@ -1,8 +1,9 @@
 package utils_test
 
 import (
-	"github.com/guidewire-oss/fern-ginkgo-client/tests"
 	"testing"
+
+	"github.com/guidewire-oss/fern-ginkgo-client/tests"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/tests/adder_suite_test.go
+++ b/tests/adder_suite_test.go
@@ -1,8 +1,9 @@
 package tests_test
 
 import (
-	"github.com/guidewire-oss/fern-ginkgo-client/tests"
 	"testing"
+
+	"github.com/guidewire-oss/fern-ginkgo-client/tests"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/tests/reporter.go
+++ b/tests/reporter.go
@@ -1,25 +1,32 @@
 package tests
 
 import (
+	"os"
+
 	"github.com/guidewire-oss/fern-ginkgo-client/pkg"
 	fern "github.com/guidewire-oss/fern-ginkgo-client/pkg/client"
 	"github.com/onsi/gomega"
-	"os"
 
 	. "github.com/onsi/ginkgo/v2"
 )
 
 func ReportTest(report Report) {
 	fernReporterBaseUrl := "http://localhost:8080/"
+	fernProjectId := pkg.PROJECT_ID
 
 	// If FERN_REPORTER_BASE_URL is set, use it
 	if os.Getenv("FERN_REPORTER_BASE_URL") != "" {
 		fernReporterBaseUrl = os.Getenv("FERN_REPORTER_BASE_URL")
 	}
 
+	if os.Getenv("PROJECT_ID") != "" {
+		fernProjectId = os.Getenv("PROJECT_ID")
+	}
+
 	if os.Getenv("GITHUB_ACTION") == "" { //skip reporting in GH workflow
-		fernApiClient := fern.New(pkg.PROJECT_ID, fern.WithBaseURL(fernReporterBaseUrl))
-		err := fernApiClient.Report(report)
+		fernApiClient, err := fern.New(fernProjectId, fern.WithBaseURL(fernReporterBaseUrl))
+		gomega.Expect(err).To(gomega.BeNil(), "Unable to create Fern API client %v", err)
+		err = fernApiClient.Report(report)
 		gomega.Expect(err).To(gomega.BeNil(), "Unable to push report to Fern %v", err)
 	}
 }


### PR DESCRIPTION
Features:
- Support sending test data to auth enabled Fern-Platform via endpoint `api/v1/test-runs`
- Temporarily support sending test data to Fern-Reporter via endpoint `api/testrun` without authentication
- Add additional unit tests
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds OAuth client-credentials to FernApiClient so test reports can be sent to auth-enabled Fern Platform. When a token is present, reports go to /api/v1/test-runs; otherwise they fall back to the legacy /api/testrun endpoint.

- New Features
  - Generate and use tokens via CLIENT_ID, CLIENT_SECRET, AUTH_URL or WithCredentials/WithToken.
  - Report adds Authorization: Bearer and targets /api/v1/test-runs when authenticated; otherwise uses /api/testrun.
  - README: added auth env var setup; tests expanded; safe ReportAfterSuite to avoid panics.

- Migration
  - New now returns (*FernApiClient, error); update call sites to handle errors.
  - Set CLIENT_ID, CLIENT_SECRET, AUTH_URL to enable authenticated reporting (optional).

<!-- End of auto-generated description by cubic. -->

