### PR TITLE
Chore: Fix readme with fern env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ Sample Response:
    ```
 4. **Authentication**: when using the Fern Platform (which has authentication enabled), set the following environment variables:
    ```shell
-    export CLIENT_ID=<Your Service Application Client ID>
-    export CLIENT_SECRET=<Your Service Application Client Secret>
+    export FERN_AUTH_CLIENT_ID=<Your Service Application Client ID>
+    export FERN_AUTH_CLIENT_SECRET=<Your Service Application Client Secret>
     export AUTH_URL=<Base URL of your authentication server>
     export FERN_GINKGO_CLIENT_SCOPE=<Fern Platform scope for Testrun write>
    ```

--- a/pkg/client/fern_api_client_test.go
+++ b/pkg/client/fern_api_client_test.go
@@ -4,7 +4,6 @@ import (
 	_ "encoding/json"
 	"errors"
 	"io"
-	"io/ioutil"
 	"net/http"
 	_ "net/http/httptest"
 	"os"
@@ -77,7 +76,7 @@ var _ = Describe("FernApiClient", func() {
 					Expect(req.URL.String()).To(Equal("http://auth/token"))
 					return &http.Response{
 						StatusCode: 200,
-						Body:       ioutil.NopCloser(strings.NewReader(tokenJSON)),
+						Body:       io.NopCloser(strings.NewReader(tokenJSON)),
 					}, nil
 				},
 			}
@@ -124,7 +123,7 @@ var _ = Describe("FernApiClient", func() {
 				roundTripFunc: func(req *http.Request) (*http.Response, error) {
 					return &http.Response{
 						StatusCode: 200,
-						Body:       ioutil.NopCloser(strings.NewReader("not-json")),
+						Body:       io.NopCloser(strings.NewReader("not-json")),
 					}, nil
 				},
 			}


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Updated README to use the correct Fern Platform auth environment variables. Replaces CLIENT_ID/CLIENT_SECRET with FERN_AUTH_CLIENT_ID/FERN_AUTH_CLIENT_SECRET to prevent setup errors during authentication setup.

<!-- End of auto-generated description by cubic. -->

