### PR TITLE
Fix: update module path to v2 for proper Go modules support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Welcome to the Fern Project, an innovative open-source solution designed to enha
 1. **Add the Fern dependency to your test project**:
 
    ```bash
-   go get -u github.com/guidewire-oss/fern-ginkgo-client
+   go get -u github.com/guidewire-oss/fern-ginkgo-client/v2
    ```
 2. **Generate Project ID by sending the below payload to `fern-reporter` (hosted in your environment)** 
 ```bash
@@ -37,7 +37,7 @@ Sample Response:
    ```
    Import the fern client package into the Ginkgo test suite file:
    ```go
-   import fern "github.com/guidewire-oss/fern-ginkgo-client/pkg/client"
+   import fern "github.com/guidewire-oss/fern-ginkgo-client/v2/pkg/client"
    ```
    Add ReportAfterSuite to call the Fern ReportTestResult.    Initialize the fernClient by passing the Project ID and ClientOption. Invoke the `Report` function by passing the report Object.
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/guidewire-oss/fern-ginkgo-client
+module github.com/guidewire-oss/fern-ginkgo-client/v2
 
 go 1.24.0
 

--- a/pkg/client/client_suite_test.go
+++ b/pkg/client/client_suite_test.go
@@ -3,7 +3,7 @@ package client_test
 import (
 	"testing"
 
-	"github.com/guidewire-oss/fern-ginkgo-client/tests"
+	"github.com/guidewire-oss/fern-ginkgo-client/v2/tests"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/pkg/client/ginkgo_fern_reporter.go
+++ b/pkg/client/ginkgo_fern_reporter.go
@@ -12,9 +12,9 @@ import (
 	"time"
 
 	"github.com/go-git/go-git/v5"
-	"github.com/guidewire-oss/fern-ginkgo-client/pkg/utils"
+	"github.com/guidewire-oss/fern-ginkgo-client/v2/pkg/utils"
 
-	"github.com/guidewire-oss/fern-ginkgo-client/pkg/models"
+	"github.com/guidewire-oss/fern-ginkgo-client/v2/pkg/models"
 
 	gt "github.com/onsi/ginkgo/v2/types"
 )

--- a/pkg/client/ginkgo_fern_reporter_test.go
+++ b/pkg/client/ginkgo_fern_reporter_test.go
@@ -3,7 +3,7 @@ package client
 import (
 	"os"
 
-	"github.com/guidewire-oss/fern-ginkgo-client/pkg/models"
+	"github.com/guidewire-oss/fern-ginkgo-client/v2/pkg/models"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )

--- a/pkg/utils/utils_suite_test.go
+++ b/pkg/utils/utils_suite_test.go
@@ -3,7 +3,7 @@ package utils_test
 import (
 	"testing"
 
-	"github.com/guidewire-oss/fern-ginkgo-client/tests"
+	"github.com/guidewire-oss/fern-ginkgo-client/v2/tests"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -2,7 +2,7 @@ package utils_test
 
 import (
 	"fmt"
-	"github.com/guidewire-oss/fern-ginkgo-client/pkg/utils"
+	"github.com/guidewire-oss/fern-ginkgo-client/v2/pkg/utils"
 	"os"
 	"path/filepath"
 	"strings"

--- a/tests/adder_suite_test.go
+++ b/tests/adder_suite_test.go
@@ -3,7 +3,7 @@ package tests_test
 import (
 	"testing"
 
-	"github.com/guidewire-oss/fern-ginkgo-client/tests"
+	"github.com/guidewire-oss/fern-ginkgo-client/v2/tests"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/tests/adder_test.go
+++ b/tests/adder_test.go
@@ -1,7 +1,7 @@
 package tests_test
 
 import (
-	. "github.com/guidewire-oss/fern-ginkgo-client/tests"
+	. "github.com/guidewire-oss/fern-ginkgo-client/v2/tests"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )

--- a/tests/reporter.go
+++ b/tests/reporter.go
@@ -3,8 +3,8 @@ package tests
 import (
 	"os"
 
-	"github.com/guidewire-oss/fern-ginkgo-client/pkg"
-	fern "github.com/guidewire-oss/fern-ginkgo-client/pkg/client"
+	"github.com/guidewire-oss/fern-ginkgo-client/v2/pkg"
+	fern "github.com/guidewire-oss/fern-ginkgo-client/v2/pkg/client"
 	"github.com/onsi/gomega"
 
 	. "github.com/onsi/ginkgo/v2"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switches the module to github.com/guidewire-oss/fern-ginkgo-client/v2 and updates all imports to use /v2 for proper Go modules major version support. This avoids v1 resolution and fixes downstream build/import errors.

- **Migration**
  - Update imports to github.com/guidewire-oss/fern-ginkgo-client/v2.
  - Run: go get -u github.com/guidewire-oss/fern-ginkgo-client/v2 && go mod tidy.

<sup>Written for commit 8f60e6eb7f3664a57b15ad02bd811aab9492510d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

