### PR TITLE
Fix: do not fail test if reporting fails

### DIFF
--- a/tests/reporter.go
+++ b/tests/reporter.go
@@ -1,11 +1,11 @@
 package tests
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/guidewire-oss/fern-ginkgo-client/v2/pkg"
 	fern "github.com/guidewire-oss/fern-ginkgo-client/v2/pkg/client"
-	"github.com/onsi/gomega"
 
 	. "github.com/onsi/ginkgo/v2"
 )
@@ -25,8 +25,13 @@ func ReportTest(report Report) {
 
 	if os.Getenv("GITHUB_ACTION") == "" { //skip reporting in GH workflow
 		fernApiClient, err := fern.New(fernProjectId, fern.WithBaseURL(fernBaseUrl))
-		gomega.Expect(err).To(gomega.BeNil(), "Unable to create Fern API client %v", err)
+		if err != nil {
+			fmt.Printf("⚠️  Fern reporting failed: unable to create Fern API client: %v\n", err)
+			return
+		}
 		err = fernApiClient.Report(report)
-		gomega.Expect(err).To(gomega.BeNil(), "Unable to push report to Fern %v", err)
+		if err != nil {
+			fmt.Printf("⚠️  Fern reporting failed: unable to push report to Fern: %v\n", err)
+		}
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make Fern reporting non-fatal so tests keep running even if the Fern client or report upload fails. Errors now print a warning; GitHub Actions already skip reporting.

- **Bug Fixes**
  - Handle errors from `github.com/guidewire-oss/fern-ginkgo-client/v2/pkg/client.New` and `Report` by logging with `fmt.Printf` instead of failing with `gomega.Expect`.
  - Preserve skip behavior when `GITHUB_ACTION` is set.

<sup>Written for commit 944ad9cf90dc8acf96cf38d2113875284bd51e2c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

